### PR TITLE
Update to latest version of nightly compiler and newest serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ keywords = ["messagepack", "binary", "encoding", "serialize"]
 license = "MPL-2.0"
 
 [dependencies]
-serde = { version = "~1.0.7", default-features = false }
+serde = { version = "~1.0.10", default-features = false }
 byteorder = { version = "~1.0", default-features = false }
 
 [dev-dependencies]
-serde_derive = "~1.0.7"
+serde_derive = "~1.0.10"
 
 [features]
 default = ["std"]
 
 std = ["serde/std"]
-collections = ["serde/collections"]
+alloc = ["serde/alloc"]

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ disable the "std" feature and enable the "collections" feature:
 corepack = { version = "~0.2.0", default-features = false, features = ["collections"] }
 ```
 
-You _must_ choose either "std" or "collections" as a feature. Corepack currently
+You _must_ choose either "std" or "alloc" as a feature. Corepack currently
 requires dynamic allocations in a few situations.

--- a/src/de.rs
+++ b/src/de.rs
@@ -3,8 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
-#[cfg(feature = "collections")]
-use collections::Vec;
+#[cfg(feature = "alloc")]
+use alloc::Vec;
 
 use std::marker::PhantomData;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,11 +5,11 @@
 // obtain one at https://mozilla.org/MPL/2.0/.
 use std::fmt::Display;
 
-#[cfg(feature = "collections")]
-use collections::String;
+#[cfg(feature = "alloc")]
+use alloc::String;
 
-#[cfg(feature = "collections")]
-use collections::string::ToString;
+#[cfg(feature = "alloc")]
+use alloc::string::ToString;
 
 use std::str::Utf8Error;
 

--- a/src/ext_deserializer.rs
+++ b/src/ext_deserializer.rs
@@ -3,8 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
-#[cfg(feature = "collections")]
-use collections::borrow::ToOwned;
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
 
 use serde::de::{MapAccess, DeserializeSeed, IntoDeserializer};
 use serde::de::value::{StrDeserializer, I8Deserializer, SeqDeserializer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 
-#![cfg_attr(feature = "collections", feature(collections))]
-#![cfg_attr(feature = "collections", feature(alloc))]
+#![cfg_attr(feature = "alloc", feature(alloc))]
 #![allow(overflowing_literals)]
 
 // testing requires std to be available
@@ -18,15 +17,12 @@ extern crate byteorder;
 #[macro_use]
 extern crate serde_derive;
 
-#[cfg(feature = "collections")]
+#[cfg(feature = "alloc")]
 #[macro_use]
-extern crate collections;
-
-#[cfg(feature = "collections")]
 extern crate alloc;
 
-#[cfg(feature = "collections")]
-use collections::Vec;
+#[cfg(feature = "alloc")]
+use alloc::Vec;
 
 pub use ser::Serializer;
 pub use de::Deserializer;

--- a/src/map_serializer.rs
+++ b/src/map_serializer.rs
@@ -3,8 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
-#[cfg(feature = "collections")]
-use collections::Vec;
+#[cfg(feature = "alloc")]
+use alloc::Vec;
 
 use serde::ser::{Serialize, SerializeMap, SerializeStruct, SerializeStructVariant};
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -5,8 +5,8 @@
 // obtain one at https://mozilla.org/MPL/2.0/.
 use std::ops::Deref;
 
-#[cfg(feature = "collections")]
-use collections::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use error::Error;
 

--- a/src/seq_serializer.rs
+++ b/src/seq_serializer.rs
@@ -3,8 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
-#[cfg(feature = "collections")]
-use collections::Vec;
+#[cfg(feature = "alloc")]
+use alloc::Vec;
 
 use serde::ser::{Serialize, SerializeSeq, SerializeTupleVariant, SerializeTuple,
                  SerializeTupleStruct};

--- a/src/variant_deserializer.rs
+++ b/src/variant_deserializer.rs
@@ -3,8 +3,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public License,
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
-#[cfg(feature = "collections")]
-use collections::borrow::ToOwned;
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
 
 use serde::de::{IntoDeserializer, DeserializeSeed, EnumAccess, Visitor, Deserialize, VariantAccess};
 use serde::de::value::StringDeserializer;


### PR DESCRIPTION
Recently the `collections` crate was merged into `alloc`. `serde` was updated to reflect this change. This pull request updates `corepack` to be compatible with new nightlies and `serde`