### PR TITLE
Update version constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MPL-2.0"
 
 [dependencies]
 serde = { version = "~1.0.10", default-features = false }
-byteorder = { version = "~1.0", default-features = false }
+byteorder = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 serde_derive = "~1.0.10"

--- a/src/variant_deserializer.rs
+++ b/src/variant_deserializer.rs
@@ -34,7 +34,7 @@ impl<'de, 'a, R: Read<'de>> EnumAccess<'de> for VariantDeserializer<'de, 'a, R> 
     type Error = Error;
     type Variant = VariantDeserializer<'de, 'a, R>;
 
-    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Error>
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Error>
         where V: DeserializeSeed<'de>
     {
         // get the variant index with a one-item tuple


### PR DESCRIPTION
Currently the version constraints on byteorder are stricter than needed and prevent users from using later versions of `byteorder`.

Also removes an unneeded `mut`.