### PR TITLE
Fix build for current nightly

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 #[cfg(feature = "alloc")]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use std::marker::PhantomData;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@
 use std::fmt::Display;
 
 #[cfg(feature = "alloc")]
-use alloc::String;
+use alloc::string::String;
 
 #[cfg(feature = "alloc")]
 use alloc::string::ToString;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ extern crate serde_derive;
 extern crate alloc;
 
 #[cfg(feature = "alloc")]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 pub use ser::Serializer;
 pub use de::Deserializer;

--- a/src/map_serializer.rs
+++ b/src/map_serializer.rs
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 #[cfg(feature = "alloc")]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use serde::ser::{Serialize, SerializeMap, SerializeStruct, SerializeStructVariant};
 

--- a/src/seq_serializer.rs
+++ b/src/seq_serializer.rs
@@ -4,7 +4,7 @@
 // v. 2.0. If a copy of the MPL was not distributed with this file, You can
 // obtain one at https://mozilla.org/MPL/2.0/.
 #[cfg(feature = "alloc")]
-use alloc::Vec;
+use alloc::vec::Vec;
 
 use serde::ser::{Serialize, SerializeSeq, SerializeTupleVariant, SerializeTuple,
                  SerializeTupleStruct};


### PR DESCRIPTION
The internal module structure of the `alloc` crate has changed, s.t. with the newest nightly compiler and the `alloc` feature enabled, the build breaks.

This PR fixes the build. The unit tests, however, continue to fail to compile.